### PR TITLE
CBD-1554 Fix forward worker restart after init fail

### DIFF
--- a/openprocurement/bridge/competitivedialogue/databridge.py
+++ b/openprocurement/bridge/competitivedialogue/databridge.py
@@ -116,6 +116,12 @@ def check_status_response(func):
         return response
     return func_wrapper
 
+def wait_initialization(func):
+    def func_wrapper(obj, *args, **kwargs):
+        gevent.wait(objects=[obj.initialization_event])
+        return func(obj, *args, **kwargs)
+    return func_wrapper
+
 
 class TendersClientSync(BaseTendersClientSync):
 
@@ -644,8 +650,8 @@ class CompetitiveDialogueDataBridge(object):
                 self.dialog_stage2_id_queue.put(dialog)
             gevent.sleep(0)
 
+    @wait_initialization()
     def get_competitive_dialogue_forward(self):
-        gevent.wait([self.initialization_event])
         logger.info('Start forward data sync worker...')
         params = {'opt_fields': 'status,procurementMethodType', 'mode': '_all_'}
         try:

--- a/openprocurement/bridge/competitivedialogue/databridge.py
+++ b/openprocurement/bridge/competitivedialogue/databridge.py
@@ -213,7 +213,6 @@ class CompetitiveDialogueDataBridge(object):
             raise ValueError
         else:
             assert 'descending' not in params
-            gevent.wait([self.initialization_event])
             self.initialization_event.clear()
             params['offset'] = self.initial_sync_point['forward_offset']
             logger.info("Starting forward sync from offset {}".format(params['offset']))
@@ -646,6 +645,7 @@ class CompetitiveDialogueDataBridge(object):
             gevent.sleep(0)
 
     def get_competitive_dialogue_forward(self):
+        gevent.wait([self.initialization_event])
         logger.info('Start forward data sync worker...')
         params = {'opt_fields': 'status,procurementMethodType', 'mode': '_all_'}
         try:


### PR DESCRIPTION
https://jira.prozorro.org/browse/CBD-1554
https://jira.prozorro.org/browse/CBD-1481

Перенесен `gevent.wait` вне метода декорированого с `@retry`, для избежания множественного линкования, и как следствие увеличение количества форвард воркеров которые создавали дубликаты stage2.

```
2018-02-12 13:04:33,731 - openprocurement.bridge.competitivedialogue.databridge - WARNING - Restarting synchronization
2018-02-12 13:04:38,733 - openprocurement.bridge.competitivedialogue.databridge - INFO - Start backward data sync worker...
2018-02-12 13:04:38,734 - openprocurement.bridge.competitivedialogue.databridge - INFO - Start forward data sync worker...
2018-02-12 13:04:38,860 - openprocurement.bridge.competitivedialogue.databridge - INFO - Initial sync point {'backward_offset': '2c00f3c19c1027873c46e74deb8fe5a4', 'forward_offset': '30366d3ad041103d70160f0b9ef85553'}
2018-02-12 13:04:38,860 - openprocurement.bridge.competitivedialogue.databridge - INFO - Client backward params: {'feed': 'changes', 'offset': '2c00f3c19c1027873c46e74deb8fe5a4', 'descending': 1, 'mode': '_all_', 'opt_fields': 'status,procurementMethodType'}
2018-02-12 13:04:38,862 - openprocurement.bridge.competitivedialogue.databridge - INFO - Sleep backward sync...
2018-02-12 13:04:38,862 - openprocurement.bridge.competitivedialogue.databridge - INFO - Starting forward sync from offset 30366d3ad041103d70160f0b9ef85553
2018-02-12 13:04:38,862 - openprocurement.bridge.competitivedialogue.databridge - INFO - Starting forward sync from offset 30366d3ad041103d70160f0b9ef85553
2018-02-12 13:04:38,863 - openprocurement.bridge.competitivedialogue.databridge - INFO - Starting forward sync from offset 30366d3ad041103d70160f0b9ef85553
2018-02-12 13:04:38,887 - openprocurement.bridge.competitivedialogue.databridge - INFO - Sleep forward sync...
2018-02-12 13:04:38,951 - openprocurement.bridge.competitivedialogue.databridge - INFO - Sleep forward sync...
2018-02-12 13:04:39,040 - openprocurement.bridge.competitivedialogue.databridge - INFO - Sleep forward sync...
```